### PR TITLE
[FEAT] The Devise form prepopulates with the Timezone from IP

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,11 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
   before_filter :authenticate_user!
 
+  Timezone::Configure.begin do |c|
+    # TODO: Fill this in with a dedicated Geonames account name
+    c.username = 'commonlisp' 
+  end
+  
   def after_sign_in_path_for(resource)
     session[root_path] || user_user_subscriptions_path(current_user.id)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+   def fetchFormatTZ()
+       begin
+         tz = Timezone::Zone.new(:latlon => request.location.coordinates)
+         z = Timezone::ActiveSupport.format(tz.zone.to_s)
+       rescue
+         z = 'Eastern Time (US & Canada)'
+       end
+   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,16 +5,14 @@
   <div class="span4">
     <%= simple_form_for(resource, :as => resource_name, :url => registration_path(resource_name), html: {class: "well"}) do |f| %>
       <%= devise_error_messages! %>
-
         <div class="form">
           <%= f.input :email %>
           <%= f.input :password %>
           <%= f.input :password_confirmation %>
           <%= f.input :time_zone, collection: ActiveSupport::TimeZone.us_zones,
           :value_method => :name, :label_method => :name, 
-          :include_blank => false, :selected => 'Pacific Time (US & Canada)' %>
+          :include_blank => false, :selected => fetchFormatTZ() %>
         </div>
-
       <div><%= f.submit "Sign up" %></div>
     <% end %>
 


### PR DESCRIPTION
It looks like you had this nearly working. The Timezone gem uses the Geonames web service (30k free requests) to find the timezone from the request IP. The timezone is also reformatted from standard to ActiveSupport::Timezone format. Timezone is supposedly doing caching. 
